### PR TITLE
Remove rate limit sleep from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,17 +32,11 @@ jobs:
             --fork=true \
             --skip=appscode-images/builder
 
-      - name: Avoid Rate Limit
-        run: sleep 30m
-
       - name: Activate Dependabot
         env:
           GH_TOOLS_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
         run: |
           gh-tools dependabot --fork=true
-
-      - name: Avoid Rate Limit
-        run: sleep 30m
 
       - name: Add Labels
         env:


### PR DESCRIPTION
## Summary
- Remove unnecessary 30-minute sleep steps from CI workflow that were used to avoid rate limits

Signed-off-by: Tamal Saha <tamal@appscode.com>